### PR TITLE
Fix search endpoint in articleService.ts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,8 +44,12 @@ const Home = () => {
       if (searchQuery.trim() === "") {
         setFilteredArticles(articles)
       } else {
-        const searchResults = await searchArticles(searchQuery)
-        setFilteredArticles(searchResults)
+        try {
+          const searchResults = await searchArticles(searchQuery)
+          setFilteredArticles(searchResults)
+        } catch (error) {
+          console.error("Error searching articles with new endpoint:", error)
+        }
       }
     }
 

--- a/services/articleService.ts
+++ b/services/articleService.ts
@@ -38,12 +38,12 @@ export const getArticle = async (articleId: number) => {
 export const searchArticles = async (query: string) => {
     try {
         const baseUrl = getBaseUrl()
-        const response = await axios.get(`${baseUrl}/articles/search`, {
+        const response = await axios.get(`${baseUrl}/articles`, {
             params: { q: query }
         })
         return response.data
     } catch (error) {
-        console.error("Error searching articles:", error)
+        console.error("Error searching articles with new endpoint:", error)
         throw error
     }
 }


### PR DESCRIPTION
Update the searchArticles function to use the correct endpoint and handle errors.

* Change the endpoint in `services/articleService.ts` from `/articles/search` to `/articles` with query parameters.
* Update the error message in `services/articleService.ts` to reflect the new endpoint.
* Update the `fetchSearchResults` function in `app/page.tsx` to handle the new search endpoint.
* Add error handling in `app/page.tsx` for the new search endpoint.

